### PR TITLE
fix: Diagnostic signs from nvim-lint not displaying correctly under certain conditions

### DIFF
--- a/lua/configs/nvim-lspconfig.lua
+++ b/lua/configs/nvim-lspconfig.lua
@@ -1,7 +1,5 @@
 local function config()
   local lsp = vim.lsp
-  local diagnostic = vim.diagnostic
-  local sev = diagnostic.severity
 
   -- Specify the config filenames to set up language servers (NOT the Mason package name)
   -- See available filenames: https://github.com/neovim/nvim-lspconfig/tree/master/lsp
@@ -34,12 +32,6 @@ local function config()
   -- })
 
   lsp.inlay_hint.enable(true)
-
-  diagnostic.config({
-    float = { border = "rounded" },
-    signs = { text = { [sev.ERROR] = "󰅚", [sev.WARN] = "󰀪", [sev.INFO] = "󰋽", [sev.HINT] = "󰌶" } },
-    virtual_text = true,
-  })
 
   if next(servers) then
     lsp.enable(servers)

--- a/lua/options.lua
+++ b/lua/options.lua
@@ -2,6 +2,8 @@ local env = vim.env
 local sep = vim.uv.os_uname().sysname == "Windows_NT" and ";" or ":"
 local o = vim.o
 local opt = vim.opt
+local diagnostic = vim.diagnostic
+local sev = diagnostic.severity
 
 -- environment variables defined in the editor session
 env.PATH = table.concat({
@@ -26,3 +28,10 @@ o.splitright = true
 o.undofile = true
 o.whichwrap = "b,s,<,>,[,]"
 o.wrap = false
+
+-- diagnostic options
+diagnostic.config({
+  float = { border = "rounded" },
+  signs = { text = { [sev.ERROR] = "󰅚", [sev.WARN] = "󰀪", [sev.INFO] = "󰋽", [sev.HINT] = "󰌶" } },
+  virtual_text = true,
+})


### PR DESCRIPTION
If nvim-lspconfig is not loaded (e.g. due to misconfiguration or an update), custom diagnostic signs may not be applied.