### PR TITLE
refactor: Remove width workaround of nvim-dap-view config

### DIFF
--- a/lua/configs/nvim-dap-view.lua
+++ b/lua/configs/nvim-dap-view.lua
@@ -2,11 +2,7 @@ local options = {
   winbar = {
     controls = {
       enabled = true,
-    },
-  },
-  windows = {
-    terminal = {
-      width = 0.35,
+      position = "left",
     },
   },
 }


### PR DESCRIPTION
Inactive headers are now configurable, so the workaround to prevent header truncation is no longer needed.