### PR TITLE
chore(treesitter): drop explicit branch specification as main is now the default

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -8,7 +8,6 @@ return {
 
   { -- Parser
     "nvim-treesitter/nvim-treesitter",
-    branch = "main",
     build = ":TSUpdate",
     event = { "BufNewFile", "BufReadPost" },
     opts = {},


### PR DESCRIPTION
refs: https://github.com/nvim-treesitter/nvim-treesitter/commit/d3218d9