### PR TITLE
chore(dap-view): follow upstream console output persistence change

### DIFF
--- a/lua/configs/nvim-dap-view.lua
+++ b/lua/configs/nvim-dap-view.lua
@@ -5,7 +5,7 @@ local options = {
       position = "left",
     },
   },
-  auto_toggle = "keep_terminal",
+  auto_toggle = true,
 }
 
 return options

--- a/lua/keymaps/nvim-dap-view.lua
+++ b/lua/keymaps/nvim-dap-view.lua
@@ -1,2 +1,2 @@
 local map = vim.keymap.set
-map("n", "<F7>", "<cmd>DapViewToggle<CR>", { desc = "Debug Toggle Session Result" })
+map("n", "<F7>", "<cmd>DapViewToggle!<CR>", { desc = "Debug Toggle Session Result" })


### PR DESCRIPTION
Upstream fixes now preserve the last console output with no active session.

refs: https://github.com/igorlfs/nvim-dap-view/commit/7a7aef3