### PR TITLE
chore(dap-view): reduce terminal window size after label behavior change

### DIFF
--- a/lua/configs/nvim-dap-view.lua
+++ b/lua/configs/nvim-dap-view.lua
@@ -5,6 +5,11 @@ local options = {
       position = "left",
     },
   },
+  windows = {
+    terminal = {
+      size = 0.3,
+    },
+  },
   auto_toggle = true,
 }
 


### PR DESCRIPTION
Temporary workaround until upstream provides a better solution for small windows.

refs:
https://github.com/igorlfs/nvim-dap-view/pull/88#issuecomment-3782428859