### PR TITLE
chore(options): disable `modeline` by default for security reasons

### DIFF
--- a/lua/options.lua
+++ b/lua/options.lua
@@ -11,6 +11,7 @@ o.tabstop = 2
 o.ignorecase = true
 o.smartcase = true
 opt.listchars = { tab = " ‥", trail = "-", nbsp = "␣", eol = "↲", space = "·", extends = "»", precedes = "«" }
+o.modeline = false
 o.mouse = "a"
 o.scrolloff = 5
 o.smartindent = true


### PR DESCRIPTION
Disable `modeline` to eliminate potential attack surface related to CVE-2026-34714.
Although the vulnerability has been patched upstream, modeline parsing remains inherently risky.

Upstream patch: https://github.com/neovim/neovim/commit/c7604323e30a235961c4a976e1c9cee20d4cfa52